### PR TITLE
fix: restore null check for displayContent in EditorContent component

### DIFF
--- a/ui/front/src/components/EditorContent.tsx
+++ b/ui/front/src/components/EditorContent.tsx
@@ -61,7 +61,6 @@ const EditorContent: React.FC<MarkDownProps> = (props) => {
     : content
 
   const displayContent = truncatedText
-  if (!displayContent || !content) return null
   const editorRef = useTiptap({
     content: displayContent || '',
     editable: false,
@@ -107,6 +106,8 @@ const EditorContent: React.FC<MarkDownProps> = (props) => {
       ''
     )
   }
+
+  if (!displayContent || !content) return null
 
   return (
     <Box


### PR DESCRIPTION
- Reintroduced the null check for displayContent and content to prevent rendering issues in the EditorContent component.