### PR TITLE
fix: update initial content in EditPage component

### DIFF
--- a/ui/front/src/app/[route_name]/edit/page.tsx
+++ b/ui/front/src/app/[route_name]/edit/page.tsx
@@ -165,7 +165,7 @@ export default function EditPage() {
         initialTitle={data.title}
         data={data}
         id={queryId}
-        initialContent={''}
+        initialContent={data.content}
         type={modalType}
         forumInfo={forumInfo}
         showContentEditor={false}


### PR DESCRIPTION
- Changed the initialContent prop in the EditPage component to use data.content instead of an empty string, ensuring that the editor is pre-filled with the correct content when editing.